### PR TITLE
bootstrap: backup existing dotfiles before sync

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,6 +62,15 @@ done
 
 # Sync dotfiles (skip in CI — runner already has ~/.bashrc etc.)
 if [ -z "${CI:-}" ]; then
+    info "Backing up existing dotfiles..."
+    for f in "$SCRIPT_DIR"/_*; do
+        target="$HOME/.$(basename "$f" | sed 's/^_//')"
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            mv "$target" "${target}.bak"
+            echo "  backed up $(basename "$target") -> $(basename "$target").bak"
+        fi
+    done
+
     info "Syncing dotfiles..."
     dotfiles --sync
     success "Dotfiles synced"


### PR DESCRIPTION
## Summary

Before `dotfiles --sync`, any existing non-symlink dotfiles are renamed to
`<file>.bak` so the sync succeeds without skipping them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)