### PR TITLE
bashrc: handle new Go-based asdf binary

### DIFF
--- a/_bashrc
+++ b/_bashrc
@@ -110,8 +110,12 @@ fi
 
 export AWS_DEFAULT_REGION=us-east-1
 
-# https://asdf-vm.com/guide/getting-started.html
-. "$HOME/.asdf/asdf.sh"
+# asdf: source shell integration for bash-based install, or add shims for Go binary install
+if [ -f "$HOME/.asdf/asdf.sh" ]; then
+    . "$HOME/.asdf/asdf.sh"
+else
+    export PATH="$HOME/.local/bin:$HOME/.asdf/shims:$PATH"
+fi
 
 function jsonArrayToTable(){
      jq -r '(.[0] | ([keys[] | .] |(., map(length*"-")))), (.[] | ([keys[] as $k | .[$k]])) | @tsv' | column -t -s $'\t'


### PR DESCRIPTION
## Summary

New asdf (Go rewrite) no longer ships `~/.asdf/asdf.sh`. Guard the source
and fall back to adding `~/.local/bin` and `~/.asdf/shims` to PATH instead.

Fixes: `source ~/.bashrc` error on fresh installs using bootstrap.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)