### PR TITLE
bashrc/bash_profile: reorganize env vars, fix duplicates, add HISTCONTROL

### DIFF
--- a/_bash_profile
+++ b/_bash_profile
@@ -8,14 +8,16 @@ fi
 # User specific environment and startup programs
 export HISTSIZE=999999
 export HISTFILESIZE=999999
+export HISTCONTROL=ignoredups:erasedups
+
+export EDITOR=vim
+export AWS_DEFAULT_REGION=us-east-1
 
 PATH=$HOME/.local/bin:$HOME/bin:$PATH:$HOME/.bin
 
 export PATH="$HOME/.tfenv/bin:$PATH"
 export PATH="${PATH}:${HOME}/.krew/bin"
 export PATH
-
-alias gcd='cd $(git root)'
 
 # If PS1 is not set, this is an automated/non-interactive shell. Skip the script utility!
 if [ -z "$PS1" ]; then

--- a/_bashrc
+++ b/_bashrc
@@ -12,9 +12,6 @@ fi
 test -f $HOME/spm/local.env && source $HOME/spm/local.env
 test -f /usr/bin/chef && eval "$(chef shell-init bash)"
 
-# PS1 Prompt with exit code. Skips 130 exit code, which is for Ctrl+C, i.e. Ctrl+C clears exit code
-PS1error="$( ret=$? ; test $ret -gt 0 -a $ret -ne 130 && echo "\[\e[41;93m\][$ret]\[\e[0m\] " )"
-
 if [ -d $HOME/.local_env ]; then
     for i in $HOME/.local_env/*.env ; do
         if [ -r "$i" ]; then
@@ -75,12 +72,8 @@ PS1='$( ret=$? ; test $ret -gt 0 -a $ret -ne 130 && echo "\[\e[41;93m\][$ret]\[\
 
 export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
-HISTFILESIZE=25000
-
 GPG_TTY=$(tty)
 export GPG_TTY
-
-export EDITOR=vim
 
 #if [[ -d "$HOME/.nvm" ]]; then
 #  export NVM_DIR="$HOME/.nvm"
@@ -98,7 +91,6 @@ if [[ -d "$HOME/perl5" ]]; then
 fi
 
 export PATH="$HOME/.java/bin:$PATH"
-export PATH="$PATH:$HOME/bin"
 
 #OktaAWSCLI
 if [[ -f "$HOME/.okta/bash_functions" ]]; then
@@ -108,14 +100,14 @@ if [[ -d "$HOME/.okta/bin" && ":$PATH:" != *":$HOME/.okta/bin:"* ]]; then
     PATH="$HOME/.okta/bin:$PATH"
 fi
 
-export AWS_DEFAULT_REGION=us-east-1
-
 # asdf: source shell integration for bash-based install, or add shims for Go binary install
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
     . "$HOME/.asdf/asdf.sh"
 else
     export PATH="$HOME/.local/bin:$HOME/.asdf/shims:$PATH"
 fi
+
+alias gcd='cd $(git root)'
 
 function jsonArrayToTable(){
      jq -r '(.[0] | ([keys[] | .] |(., map(length*"-")))), (.[] | ([keys[] as $k | .[$k]])) | @tsv' | column -t -s $'\t'


### PR DESCRIPTION
## Summary

- `HISTCONTROL=ignoredups:erasedups` added next to HISTSIZE/HISTFILESIZE in bash_profile
- `EDITOR`, `AWS_DEFAULT_REGION` moved to bash_profile (env vars belong there)
- `alias gcd` moved to bashrc (aliases need to be set for every shell)
- Removed duplicate `$HOME/bin` from bashrc (already in bash_profile)
- Removed duplicate `HISTFILESIZE=25000` from bashrc (conflict with 999999 in bash_profile)
- Removed dead `PS1error` variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)